### PR TITLE
filter results by DOI name

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -101,7 +101,7 @@ class Work < Base
   def self.get_query_url(options={})
     if options[:id].present?
       params = { q: options[:id],
-                 fq: "doi:#{options[:id].dump}" ,
+                 fq: "doi:#{options[:id].dump}",
                  defType: "edismax",
                  wt: "json" }
     elsif options[:work_id].present?

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -101,6 +101,7 @@ class Work < Base
   def self.get_query_url(options={})
     if options[:id].present?
       params = { q: options[:id],
+                 fq: "doi:#{options[:id].dump}" ,
                  defType: "edismax",
                  wt: "json" }
     elsif options[:work_id].present?

--- a/spec/fixtures/vcr_cassettes/Works/work.yml
+++ b/spec/fixtures/vcr_cassettes/Works/work.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://solr.test.datacite.org/api?defType=edismax&q=10.4124/9f7xnnys8c.5&wt=json
+    uri: https://solr.test.datacite.org/api?defType=edismax&fq=doi:%2210.4124/9f7xnnys8c.5%22&q=10.4124/9f7xnnys8c.5&wt=json
     body:
       encoding: US-ASCII
       string: ''
@@ -17,7 +17,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Apr 2018 07:06:10 GMT
+      - Tue, 19 Jun 2018 20:01:08 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Connection:
@@ -34,16 +34,16 @@ http_interactions:
       - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
     body:
       encoding: ASCII-8BIT
-      string: '{"responseHeader":{"status":0,"QTime":1},"response":{"numFound":1,"start":0,"docs":[{"is_active":true,"created":"2017-12-15T17:55:44Z","prefix":"10.4124","dataset_id":"2172984","has_media":false,"datacentre_symbol":"BL.MENDELEY","datacentre":"BL.MENDELEY
+      string: '{"responseHeader":{"status":0,"QTime":7},"response":{"numFound":1,"start":0,"docs":[{"is_active":true,"created":"2017-12-15T17:55:44Z","prefix":"10.4124","dataset_id":"2172984","has_media":false,"datacentre_symbol":"BL.MENDELEY","datacentre":"BL.MENDELEY
         - Mendeley Data","datacentre_facet":"BL.MENDELEY - Mendeley Data","allocator":"BL
         - The British Library","allocator_facet":"BL - The British Library","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KCjxyZXNvdXJjZSB4bWxucz0iaHR0cDovL2RhdGFjaXRlLm9yZy9zY2hlbWEva2VybmVsLTMiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhzaTpzY2hlbWFMb2NhdGlvbj0iaHR0cDovL2RhdGFjaXRlLm9yZy9zY2hlbWEva2VybmVsLTMgaHR0cDovL3NjaGVtYS5kYXRhY2l0ZS5vcmcvbWV0YS9rZXJuZWwtMy9tZXRhZGF0YS54c2QiPgogIDxpZGVudGlmaWVyIGlkZW50aWZpZXJUeXBlPSJET0kiPjEwLjQxMjQvOWY3eG5ueXM4Yy41PC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWU+TmF0cmEsIE1haGVzaDwvY3JlYXRvck5hbWU+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzPgogICAgPHRpdGxlPkRBVC0zMDI1IE1haW50YWluIGZpbGUgb3JkZXJpbmcgZm9yIHB1Ymxpc2hlZCBkYXRhc2V0cyAtIDQ8L3RpdGxlPgogIDwvdGl0bGVzPgogIDxwdWJsaXNoZXI+TWVuZGVsZXk8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTg8L3B1YmxpY2F0aW9uWWVhcj4KICA8c3ViamVjdHM+CiAgICA8c3ViamVjdD5NYXRoZW1hdGljczwvc3ViamVjdD4KICA8L3N1YmplY3RzPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJBdmFpbGFibGUiPjIwMTgtMTItMjE8L2RhdGU+CiAgPC9kYXRlcz4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IkRhdGFzZXQiPkRhdGFzZXQ8L3Jlc291cmNlVHlwZT4KICA8cmlnaHRzTGlzdD4KICAgIDxyaWdodHMgcmlnaHRzVVJJPSJpbmZvOmV1LXJlcG8vc2VtYW50aWNzL2VtYmFyZ29lZEFjY2VzcyIvPgogICAgPHJpZ2h0cyByaWdodHNVUkk9Imh0dHA6Ly9jcmVhdGl2ZWNvbW1vbnMub3JnL2xpY2Vuc2VzL2J5LzQuMCI+Q3JlYXRpdmUgQ29tbW9ucyBBdHRyaWJ1dGlvbiA0LjAgSW50ZXJuYXRpb25hbCAoRW1iYXJnbzogMjAxOC0xMi0yMSk8L3JpZ2h0cz4KICA8L3JpZ2h0c0xpc3Q+CjwvcmVzb3VyY2U+Cg==","has_metadata":true,"allocator_symbol":"BL","uploaded":"2017-12-15T17:55:44Z","namespace":"http://datacite.org/schema/kernel-3","minted":"2017-12-15T17:55:44Z","state":"findable","updated":"2017-12-15T17:55:44Z","doi":"10.4124/9F7XNNYS8C.5","schema_version":"3","date":["2018-12-21"],"creator":["Natra,
         Mahesh"],"resourceTypeGeneral":"Dataset","spdx":["info:eu-repo/semantics/embargoedAccess","http://creativecommons.org/licenses/by/4.0/legalcode"],"subject":["Mathematics"],"title":["DAT-3025
         Maintain file ordering for published datasets - 4"],"dateType":["Available"],"rightsURI":["info:eu-repo/semantics/embargoedAccess","http://creativecommons.org/licenses/by/4.0"],"rights":["","Creative
-        Commons Attribution 4.0 International (Embargo: 2018-12-21)"],"publisher":"Mendeley","publicationYear":"2018","resourceType":"Dataset","_version_":1597432227627532290,"indexed":"2018-04-11T07:01:27.688Z"}]}}
+        Commons Attribution 4.0 International (Embargo: 2018-12-21)"],"publisher":"Mendeley","publicationYear":"2018","resourceType":"Dataset","_version_":1603732176892854273,"indexed":"2018-06-19T19:56:27.497Z"}]}}
 
 '
     http_version: 
-  recorded_at: Wed, 11 Apr 2018 07:06:09 GMT
+  recorded_at: Tue, 19 Jun 2018 20:01:12 GMT
 - request:
     method: get
     uri: https://schema.test.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd
@@ -65,7 +65,7 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Wed, 11 Apr 2018 07:03:59 GMT
+      - Tue, 19 Jun 2018 19:38:37 GMT
       Content-Encoding:
       - text
       Last-Modified:
@@ -75,13 +75,13 @@ http_interactions:
       Server:
       - AmazonS3
       Age:
-      - '132'
+      - '1352'
       X-Cache:
       - Hit from cloudfront
       Via:
-      - 1.1 f2cc6dbe7150e50a6bc010a2d6868e5f.cloudfront.net (CloudFront)
+      - 1.1 002c7dd628aeaafbb16627d6bb5046c9.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - yZ2Ggn_KOPjMDHgWVlf97bZpTcmFyg4F6MC-N7J3fwI5SwUm95aB1Q==
+      - n7GEs-WO9UMOIkSudDAt25-HeHAhiLYML2QBbDEdapF45jGQiMcU7A==
     body:
       encoding: ASCII-8BIT
       string: |
@@ -114,10 +114,10 @@ http_interactions:
           </xs:simpleType>
         </xs:schema>
     http_version: 
-  recorded_at: Wed, 11 Apr 2018 07:06:09 GMT
+  recorded_at: Tue, 19 Jun 2018 20:01:12 GMT
 - request:
     method: get
-    uri: https://app.test.datacite.org/clients/bl.mendeley
+    uri: https://app.datacite.org/clients/bl.mendeley
     body:
       encoding: US-ASCII
       string: ''
@@ -132,7 +132,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Apr 2018 07:06:10 GMT
+      - Tue, 19 Jun 2018 20:01:08 GMT
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Connection:
@@ -146,20 +146,19 @@ http_interactions:
       Vary:
       - Accept-Encoding, Origin
       X-Request-Id:
-      - 94415640-143a-46e7-8a36-7d5c961e2375
+      - f981c874-c9e1-4474-b9e7-18ffcd809207
       Etag:
-      - W/"2e66bbd8ba14b36e18c4d94821852d8e"
+      - W/"5ff6592e2e2de822c5b11643f9e85db5"
       X-Runtime:
-      - '0.008951'
+      - '0.008992'
       X-Powered-By:
-      - Phusion Passenger 5.2.3
+      - Phusion Passenger 5.3.2
       Server:
-      - nginx/1.12.2 + Phusion Passenger 5.2.3
+      - nginx/1.14.0 + Phusion Passenger 5.3.2
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"bl.mendeley","type":"clients","attributes":{"name":"Mendeley
-        Data","symbol":"BL.MENDELEY","year":2014,"contact-name":"Josh Emerson","contact-email":"josh.emerson@mendeley.com","domains":"mendeley.com","url":null,"is-active":true,"has-password":true,"created":"2014-10-03T15:53:41Z","updated":"2018-04-11T01:30:37Z"},"relationships":{"prefixes":{"meta":{}},"provider":{"data":{"id":"bl","type":"providers"}},"repository":{"data":null}}},"included":[{"id":"bl","type":"providers","attributes":{"name":"The
-        British Library","symbol":"BL","website":null,"contact-name":"Rachael Kotarski","contact-email":"datasets@bl.uk","phone":null,"description":null,"country":null,"logo-url":null,"institution-type":null,"is-active":true,"has-password":true,"joined":null,"created":"2010-01-01T00:00:00.000Z","updated":"2018-04-11T01:25:40.000Z"},"relationships":{"clients":{"meta":{}},"prefixes":{"meta":{}}}}],"meta":{"dois":[{"id":2014,"title":2014,"count":2640},{"id":2015,"title":2015,"count":96215},{"id":2016,"title":2016,"count":19451},{"id":2017,"title":2017,"count":3568},{"id":2018,"title":2018,"count":180}]}}'
+      string: !binary |-
+        eyJkYXRhIjp7ImlkIjoiYmwubWVuZGVsZXkiLCJ0eXBlIjoiY2xpZW50cyIsImF0dHJpYnV0ZXMiOnsibmFtZSI6Ik1lbmRlbGV5Iiwic3ltYm9sIjoiQkwuTUVOREVMRVkiLCJ5ZWFyIjoyMDE1LCJjb250YWN0LW5hbWUiOiJKb3NoIEVtZXJzb24iLCJjb250YWN0LWVtYWlsIjoiam9zaC5lbWVyc29uQG1lbmRlbGV5LmNvbSIsImRvbWFpbnMiOiJtZW5kZWxleS5jb20iLCJ1cmwiOm51bGwsImlzLWFjdGl2ZSI6dHJ1ZSwiaGFzLXBhc3N3b3JkIjp0cnVlLCJjcmVhdGVkIjoiMjAxNS0wNC0wOVQxMDowMzo0OVoiLCJ1cGRhdGVkIjoiMjAxOC0wNi0xOVQwMjozMDoyOFoifSwicmVsYXRpb25zaGlwcyI6eyJwcmVmaXhlcyI6eyJtZXRhIjp7fX0sInByb3ZpZGVyIjp7ImRhdGEiOnsiaWQiOiJibCIsInR5cGUiOiJwcm92aWRlcnMifX0sInJlcG9zaXRvcnkiOnsiZGF0YSI6eyJpZCI6InIzZDEwMDAxMTg2OCIsInR5cGUiOiJyZXBvc2l0b3JpZXMifX19fSwiaW5jbHVkZWQiOlt7ImlkIjoiYmwiLCJ0eXBlIjoicHJvdmlkZXJzIiwiYXR0cmlidXRlcyI6eyJuYW1lIjoiQnJpdGlzaCBMaWJyYXJ5Iiwic3ltYm9sIjoiQkwiLCJ3ZWJzaXRlIjoiaHR0cDovL3d3dy5ibC51ay9kYXRhc2V0cyIsImNvbnRhY3QtbmFtZSI6IlJhY2hhZWwgS290YXJza2kiLCJjb250YWN0LWVtYWlsIjoiZGF0YXNldHNAYmwudWsiLCJwaG9uZSI6Iis0NCAoMCkgMjA3IDQxMiA3MTY3IiwiZGVzY3JpcHRpb24iOiJUaGUgQnJpdGlzaCBMaWJyYXJ5IGlzIHRoZSBuYXRpb25hbCBsaWJyYXJ5IG9mIHRoZSBVbml0ZWQgS2luZ2RvbSBhbmQgYSBmb3VuZGluZyBtZW1iZXIgb2YgRGF0YUNpdGUuIEFzIERhdGFDaXRl4oCZcyBvbmx5IG1lbWJlciBpbiB0aGUgVW5pdGVkIEtpbmdkb20sIHdlIGFyZSB3b3JraW5nIHdpdGggVUsgb3JnYW5pc2F0aW9ucyB0byBlbnN1cmUgdGhhdCBkYXRhIGdlbmVyYXRlZCBieSByZXNlYXJjaGVycyBpcyBmaW5kYWJsZSBhbmQgY2l0YWJsZSBzbyB0aGF0IGl0cyBpbXBhY3Qgb24gdGhlIGdsb2JhbCByZXNlYXJjaCBsYW5kc2NhcGUgaXMgcmVjb2duaXNlZC4gV2Ugd29yayB3aXRoIGEgcmFuZ2Ugb2Ygb3JnYW5pc2F0aW9ucyB3aG8gbWFuYWdlIGFuZCBhcmNoaXZlIGRhdGEsIGZyb20gZ292ZXJubWVudCBib2RpZXMgdG8gY2hhcml0aWVzLCB1bml2ZXJzaXRpZXMgYW5kIHB1Ymxpc2hlcnMuIElmIHlvdSBtYW5hZ2UgZGF0YSBpbiB0aGUgVUsgYW5kIHdvdWxkIGxpa2UgdG8gZmluZCBvdXQgbW9yZSBhYm91dCBEYXRhQ2l0ZSwgcGxlYXNlIGNvbnRhY3QgdXMgZGlyZWN0bHkuIiwiY291bnRyeSI6IkdCIiwibG9nby11cmwiOiJodHRwczovL2Fzc2V0cy5kYXRhY2l0ZS5vcmcvaW1hZ2VzL21lbWJlcnMvYmwucG5nIiwiaW5zdGl0dXRpb24tdHlwZSI6bnVsbCwiaXMtYWN0aXZlIjp0cnVlLCJoYXMtcGFzc3dvcmQiOnRydWUsImpvaW5lZCI6IjIwMDktMTItMDEiLCJjcmVhdGVkIjoiMjAxMC0wMS0wMVQwMDowMDowMC4wMDBaIiwidXBkYXRlZCI6IjIwMTgtMDYtMTlUMDI6MjU6NTguMDAwWiJ9LCJyZWxhdGlvbnNoaXBzIjp7ImNsaWVudHMiOnsibWV0YSI6e319LCJwcmVmaXhlcyI6eyJtZXRhIjp7fX19fSx7ImlkIjoicjNkMTAwMDExODY4IiwidHlwZSI6InJlcG9zaXRvcmllcyIsImF0dHJpYnV0ZXMiOnsibmFtZSI6Ik1lbmRlbGV5IERhdGEiLCJhZGRpdGlvbmFsLW5hbWUiOm51bGwsImRlc2NyaXB0aW9uIjoiRm9yIGRhdGFzZXRzIGJpZyBhbmQgc21hbGw7IFN0b3JlIHlvdXIgcmVzZWFyY2ggZGF0YSBvbmxpbmUuIFF1aWNrbHkgYW5kIGVhc2lseSB1cGxvYWQgZmlsZXMgb2YgYW55IHR5cGUgYW5kIHdlIHdpbGwgaG9zdCB5b3VyIHJlc2VhcmNoIGRhdGEgZm9yIHlvdS4gWW91ciBleHBlcmltZW50YWwgcmVzZWFyY2ggZGF0YSB3aWxsIGhhdmUgYSBwZXJtYW5lbnQgaG9tZSBvbiB0aGUgd2ViIHRoYXQgeW91IGNhbiByZWZlciB0by4iLCJyZXBvc2l0b3J5LXVybCI6Imh0dHBzOi8vZGF0YS5tZW5kZWxleS5jb20vIiwicmVwb3NpdG9yeS1jb250YWN0IjoiZGF0YUBtZW5kZWxleS5jb20iLCJzdWJqZWN0IjpbeyJpZCI6MSwibmFtZSI6Ikh1bWFuaXRpZXMgYW5kIFNvY2lhbCBTY2llbmNlcyJ9LHsiaWQiOjIsIm5hbWUiOiJMaWZlIFNjaWVuY2VzIn0seyJpZCI6MywibmFtZSI6Ik5hdHVyYWwgU2NpZW5jZXMifSx7ImlkIjo0LCJuYW1lIjoiRW5naW5lZXJpbmcgU2NpZW5jZXMifV0sInJlcG9zaXRvcnktc29mdHdhcmUiOiJvdGhlciIsImNyZWF0ZWQiOiIyMDE1LTEwLTIzVDAwOjAwOjAwWiIsInVwZGF0ZWQiOiIyMDE4LTA1LTI4VDAwOjAwOjAwWiJ9fV0sIm1ldGEiOnsiZG9pcyI6W3siaWQiOjIwMTUsInRpdGxlIjoyMDE1LCJjb3VudCI6MTQzfSx7ImlkIjoyMDE2LCJ0aXRsZSI6MjAxNiwiY291bnQiOjM4NDd9LHsiaWQiOjIwMTcsInRpdGxlIjoyMDE3LCJjb3VudCI6NzU5MX0seyJpZCI6MjAxOCwidGl0bGUiOjIwMTgsImNvdW50IjozMTEyfV19fQ==
     http_version: 
-  recorded_at: Wed, 11 Apr 2018 07:06:09 GMT
+  recorded_at: Tue, 19 Jun 2018 20:01:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Works/work.yml
+++ b/spec/fixtures/vcr_cassettes/Works/work.yml
@@ -17,7 +17,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jun 2018 20:01:08 GMT
+      - Tue, 19 Jun 2018 20:14:04 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Connection:
@@ -34,16 +34,16 @@ http_interactions:
       - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
     body:
       encoding: ASCII-8BIT
-      string: '{"responseHeader":{"status":0,"QTime":7},"response":{"numFound":1,"start":0,"docs":[{"is_active":true,"created":"2017-12-15T17:55:44Z","prefix":"10.4124","dataset_id":"2172984","has_media":false,"datacentre_symbol":"BL.MENDELEY","datacentre":"BL.MENDELEY
+      string: '{"responseHeader":{"status":0,"QTime":4},"response":{"numFound":1,"start":0,"docs":[{"is_active":true,"created":"2017-12-15T17:55:44Z","prefix":"10.4124","dataset_id":"2172984","has_media":false,"datacentre_symbol":"BL.MENDELEY","datacentre":"BL.MENDELEY
         - Mendeley Data","datacentre_facet":"BL.MENDELEY - Mendeley Data","allocator":"BL
         - The British Library","allocator_facet":"BL - The British Library","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KCjxyZXNvdXJjZSB4bWxucz0iaHR0cDovL2RhdGFjaXRlLm9yZy9zY2hlbWEva2VybmVsLTMiIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhzaTpzY2hlbWFMb2NhdGlvbj0iaHR0cDovL2RhdGFjaXRlLm9yZy9zY2hlbWEva2VybmVsLTMgaHR0cDovL3NjaGVtYS5kYXRhY2l0ZS5vcmcvbWV0YS9rZXJuZWwtMy9tZXRhZGF0YS54c2QiPgogIDxpZGVudGlmaWVyIGlkZW50aWZpZXJUeXBlPSJET0kiPjEwLjQxMjQvOWY3eG5ueXM4Yy41PC9pZGVudGlmaWVyPgogIDxjcmVhdG9ycz4KICAgIDxjcmVhdG9yPgogICAgICA8Y3JlYXRvck5hbWU+TmF0cmEsIE1haGVzaDwvY3JlYXRvck5hbWU+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzPgogICAgPHRpdGxlPkRBVC0zMDI1IE1haW50YWluIGZpbGUgb3JkZXJpbmcgZm9yIHB1Ymxpc2hlZCBkYXRhc2V0cyAtIDQ8L3RpdGxlPgogIDwvdGl0bGVzPgogIDxwdWJsaXNoZXI+TWVuZGVsZXk8L3B1Ymxpc2hlcj4KICA8cHVibGljYXRpb25ZZWFyPjIwMTg8L3B1YmxpY2F0aW9uWWVhcj4KICA8c3ViamVjdHM+CiAgICA8c3ViamVjdD5NYXRoZW1hdGljczwvc3ViamVjdD4KICA8L3N1YmplY3RzPgogIDxkYXRlcz4KICAgIDxkYXRlIGRhdGVUeXBlPSJBdmFpbGFibGUiPjIwMTgtMTItMjE8L2RhdGU+CiAgPC9kYXRlcz4KICA8cmVzb3VyY2VUeXBlIHJlc291cmNlVHlwZUdlbmVyYWw9IkRhdGFzZXQiPkRhdGFzZXQ8L3Jlc291cmNlVHlwZT4KICA8cmlnaHRzTGlzdD4KICAgIDxyaWdodHMgcmlnaHRzVVJJPSJpbmZvOmV1LXJlcG8vc2VtYW50aWNzL2VtYmFyZ29lZEFjY2VzcyIvPgogICAgPHJpZ2h0cyByaWdodHNVUkk9Imh0dHA6Ly9jcmVhdGl2ZWNvbW1vbnMub3JnL2xpY2Vuc2VzL2J5LzQuMCI+Q3JlYXRpdmUgQ29tbW9ucyBBdHRyaWJ1dGlvbiA0LjAgSW50ZXJuYXRpb25hbCAoRW1iYXJnbzogMjAxOC0xMi0yMSk8L3JpZ2h0cz4KICA8L3JpZ2h0c0xpc3Q+CjwvcmVzb3VyY2U+Cg==","has_metadata":true,"allocator_symbol":"BL","uploaded":"2017-12-15T17:55:44Z","namespace":"http://datacite.org/schema/kernel-3","minted":"2017-12-15T17:55:44Z","state":"findable","updated":"2017-12-15T17:55:44Z","doi":"10.4124/9F7XNNYS8C.5","schema_version":"3","date":["2018-12-21"],"creator":["Natra,
         Mahesh"],"resourceTypeGeneral":"Dataset","spdx":["info:eu-repo/semantics/embargoedAccess","http://creativecommons.org/licenses/by/4.0/legalcode"],"subject":["Mathematics"],"title":["DAT-3025
         Maintain file ordering for published datasets - 4"],"dateType":["Available"],"rightsURI":["info:eu-repo/semantics/embargoedAccess","http://creativecommons.org/licenses/by/4.0"],"rights":["","Creative
-        Commons Attribution 4.0 International (Embargo: 2018-12-21)"],"publisher":"Mendeley","publicationYear":"2018","resourceType":"Dataset","_version_":1603732176892854273,"indexed":"2018-06-19T19:56:27.497Z"}]}}
+        Commons Attribution 4.0 International (Embargo: 2018-12-21)"],"publisher":"Mendeley","publicationYear":"2018","resourceType":"Dataset","_version_":1603733120708771841,"indexed":"2018-06-19T20:11:27.59Z"}]}}
 
 '
     http_version: 
-  recorded_at: Tue, 19 Jun 2018 20:01:12 GMT
+  recorded_at: Tue, 19 Jun 2018 20:14:09 GMT
 - request:
     method: get
     uri: https://schema.test.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd
@@ -75,13 +75,13 @@ http_interactions:
       Server:
       - AmazonS3
       Age:
-      - '1352'
+      - '2128'
       X-Cache:
       - Hit from cloudfront
       Via:
-      - 1.1 002c7dd628aeaafbb16627d6bb5046c9.cloudfront.net (CloudFront)
+      - 1.1 55ee6ea70e0823309f10db2e4b8f119f.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - n7GEs-WO9UMOIkSudDAt25-HeHAhiLYML2QBbDEdapF45jGQiMcU7A==
+      - G2C35TPlJkNHRV2w6XdUTNR06gqwGj7iFiLOHyVAoIkTgUJYd2L07g==
     body:
       encoding: ASCII-8BIT
       string: |
@@ -114,10 +114,10 @@ http_interactions:
           </xs:simpleType>
         </xs:schema>
     http_version: 
-  recorded_at: Tue, 19 Jun 2018 20:01:12 GMT
+  recorded_at: Tue, 19 Jun 2018 20:14:09 GMT
 - request:
     method: get
-    uri: https://app.datacite.org/clients/bl.mendeley
+    uri: https://app.test.datacite.org/clients/bl.mendeley
     body:
       encoding: US-ASCII
       string: ''
@@ -132,7 +132,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jun 2018 20:01:08 GMT
+      - Tue, 19 Jun 2018 20:14:04 GMT
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Connection:
@@ -146,19 +146,20 @@ http_interactions:
       Vary:
       - Accept-Encoding, Origin
       X-Request-Id:
-      - f981c874-c9e1-4474-b9e7-18ffcd809207
+      - 2e700b26-a567-467a-88f0-1761b65bad27
       Etag:
-      - W/"5ff6592e2e2de822c5b11643f9e85db5"
+      - W/"68f237cfb904f7f8b1458b87c8aedfb6"
       X-Runtime:
-      - '0.008992'
+      - '0.176238'
       X-Powered-By:
       - Phusion Passenger 5.3.2
       Server:
       - nginx/1.14.0 + Phusion Passenger 5.3.2
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        eyJkYXRhIjp7ImlkIjoiYmwubWVuZGVsZXkiLCJ0eXBlIjoiY2xpZW50cyIsImF0dHJpYnV0ZXMiOnsibmFtZSI6Ik1lbmRlbGV5Iiwic3ltYm9sIjoiQkwuTUVOREVMRVkiLCJ5ZWFyIjoyMDE1LCJjb250YWN0LW5hbWUiOiJKb3NoIEVtZXJzb24iLCJjb250YWN0LWVtYWlsIjoiam9zaC5lbWVyc29uQG1lbmRlbGV5LmNvbSIsImRvbWFpbnMiOiJtZW5kZWxleS5jb20iLCJ1cmwiOm51bGwsImlzLWFjdGl2ZSI6dHJ1ZSwiaGFzLXBhc3N3b3JkIjp0cnVlLCJjcmVhdGVkIjoiMjAxNS0wNC0wOVQxMDowMzo0OVoiLCJ1cGRhdGVkIjoiMjAxOC0wNi0xOVQwMjozMDoyOFoifSwicmVsYXRpb25zaGlwcyI6eyJwcmVmaXhlcyI6eyJtZXRhIjp7fX0sInByb3ZpZGVyIjp7ImRhdGEiOnsiaWQiOiJibCIsInR5cGUiOiJwcm92aWRlcnMifX0sInJlcG9zaXRvcnkiOnsiZGF0YSI6eyJpZCI6InIzZDEwMDAxMTg2OCIsInR5cGUiOiJyZXBvc2l0b3JpZXMifX19fSwiaW5jbHVkZWQiOlt7ImlkIjoiYmwiLCJ0eXBlIjoicHJvdmlkZXJzIiwiYXR0cmlidXRlcyI6eyJuYW1lIjoiQnJpdGlzaCBMaWJyYXJ5Iiwic3ltYm9sIjoiQkwiLCJ3ZWJzaXRlIjoiaHR0cDovL3d3dy5ibC51ay9kYXRhc2V0cyIsImNvbnRhY3QtbmFtZSI6IlJhY2hhZWwgS290YXJza2kiLCJjb250YWN0LWVtYWlsIjoiZGF0YXNldHNAYmwudWsiLCJwaG9uZSI6Iis0NCAoMCkgMjA3IDQxMiA3MTY3IiwiZGVzY3JpcHRpb24iOiJUaGUgQnJpdGlzaCBMaWJyYXJ5IGlzIHRoZSBuYXRpb25hbCBsaWJyYXJ5IG9mIHRoZSBVbml0ZWQgS2luZ2RvbSBhbmQgYSBmb3VuZGluZyBtZW1iZXIgb2YgRGF0YUNpdGUuIEFzIERhdGFDaXRl4oCZcyBvbmx5IG1lbWJlciBpbiB0aGUgVW5pdGVkIEtpbmdkb20sIHdlIGFyZSB3b3JraW5nIHdpdGggVUsgb3JnYW5pc2F0aW9ucyB0byBlbnN1cmUgdGhhdCBkYXRhIGdlbmVyYXRlZCBieSByZXNlYXJjaGVycyBpcyBmaW5kYWJsZSBhbmQgY2l0YWJsZSBzbyB0aGF0IGl0cyBpbXBhY3Qgb24gdGhlIGdsb2JhbCByZXNlYXJjaCBsYW5kc2NhcGUgaXMgcmVjb2duaXNlZC4gV2Ugd29yayB3aXRoIGEgcmFuZ2Ugb2Ygb3JnYW5pc2F0aW9ucyB3aG8gbWFuYWdlIGFuZCBhcmNoaXZlIGRhdGEsIGZyb20gZ292ZXJubWVudCBib2RpZXMgdG8gY2hhcml0aWVzLCB1bml2ZXJzaXRpZXMgYW5kIHB1Ymxpc2hlcnMuIElmIHlvdSBtYW5hZ2UgZGF0YSBpbiB0aGUgVUsgYW5kIHdvdWxkIGxpa2UgdG8gZmluZCBvdXQgbW9yZSBhYm91dCBEYXRhQ2l0ZSwgcGxlYXNlIGNvbnRhY3QgdXMgZGlyZWN0bHkuIiwiY291bnRyeSI6IkdCIiwibG9nby11cmwiOiJodHRwczovL2Fzc2V0cy5kYXRhY2l0ZS5vcmcvaW1hZ2VzL21lbWJlcnMvYmwucG5nIiwiaW5zdGl0dXRpb24tdHlwZSI6bnVsbCwiaXMtYWN0aXZlIjp0cnVlLCJoYXMtcGFzc3dvcmQiOnRydWUsImpvaW5lZCI6IjIwMDktMTItMDEiLCJjcmVhdGVkIjoiMjAxMC0wMS0wMVQwMDowMDowMC4wMDBaIiwidXBkYXRlZCI6IjIwMTgtMDYtMTlUMDI6MjU6NTguMDAwWiJ9LCJyZWxhdGlvbnNoaXBzIjp7ImNsaWVudHMiOnsibWV0YSI6e319LCJwcmVmaXhlcyI6eyJtZXRhIjp7fX19fSx7ImlkIjoicjNkMTAwMDExODY4IiwidHlwZSI6InJlcG9zaXRvcmllcyIsImF0dHJpYnV0ZXMiOnsibmFtZSI6Ik1lbmRlbGV5IERhdGEiLCJhZGRpdGlvbmFsLW5hbWUiOm51bGwsImRlc2NyaXB0aW9uIjoiRm9yIGRhdGFzZXRzIGJpZyBhbmQgc21hbGw7IFN0b3JlIHlvdXIgcmVzZWFyY2ggZGF0YSBvbmxpbmUuIFF1aWNrbHkgYW5kIGVhc2lseSB1cGxvYWQgZmlsZXMgb2YgYW55IHR5cGUgYW5kIHdlIHdpbGwgaG9zdCB5b3VyIHJlc2VhcmNoIGRhdGEgZm9yIHlvdS4gWW91ciBleHBlcmltZW50YWwgcmVzZWFyY2ggZGF0YSB3aWxsIGhhdmUgYSBwZXJtYW5lbnQgaG9tZSBvbiB0aGUgd2ViIHRoYXQgeW91IGNhbiByZWZlciB0by4iLCJyZXBvc2l0b3J5LXVybCI6Imh0dHBzOi8vZGF0YS5tZW5kZWxleS5jb20vIiwicmVwb3NpdG9yeS1jb250YWN0IjoiZGF0YUBtZW5kZWxleS5jb20iLCJzdWJqZWN0IjpbeyJpZCI6MSwibmFtZSI6Ikh1bWFuaXRpZXMgYW5kIFNvY2lhbCBTY2llbmNlcyJ9LHsiaWQiOjIsIm5hbWUiOiJMaWZlIFNjaWVuY2VzIn0seyJpZCI6MywibmFtZSI6Ik5hdHVyYWwgU2NpZW5jZXMifSx7ImlkIjo0LCJuYW1lIjoiRW5naW5lZXJpbmcgU2NpZW5jZXMifV0sInJlcG9zaXRvcnktc29mdHdhcmUiOiJvdGhlciIsImNyZWF0ZWQiOiIyMDE1LTEwLTIzVDAwOjAwOjAwWiIsInVwZGF0ZWQiOiIyMDE4LTA1LTI4VDAwOjAwOjAwWiJ9fV0sIm1ldGEiOnsiZG9pcyI6W3siaWQiOjIwMTUsInRpdGxlIjoyMDE1LCJjb3VudCI6MTQzfSx7ImlkIjoyMDE2LCJ0aXRsZSI6MjAxNiwiY291bnQiOjM4NDd9LHsiaWQiOjIwMTcsInRpdGxlIjoyMDE3LCJjb3VudCI6NzU5MX0seyJpZCI6MjAxOCwidGl0bGUiOjIwMTgsImNvdW50IjozMTEyfV19fQ==
+      string: '{"data":{"id":"bl.mendeley","type":"clients","attributes":{"name":"Mendeley
+        Data","symbol":"BL.MENDELEY","year":2014,"contact-name":"Josh Emerson","contact-email":"josh.emerson@mendeley.com","domains":"mendeley.com","url":null,"is-active":true,"has-password":true,"created":"2014-10-03T15:53:41Z","updated":"2018-06-19T01:30:48Z"},"relationships":{"prefixes":{"meta":{}},"provider":{"data":{"id":"bl","type":"providers"}},"repository":{"data":null}}},"included":[{"id":"bl","type":"providers","attributes":{"name":"The
+        British Library","symbol":"BL","website":null,"contact-name":"Rachael Kotarski","contact-email":"datasets@bl.uk","phone":null,"description":null,"country":null,"logo-url":null,"institution-type":null,"is-active":true,"has-password":true,"joined":null,"created":"2010-01-01T00:00:00.000Z","updated":"2018-06-19T01:25:39.000Z"},"relationships":{"clients":{"meta":{}},"prefixes":{"meta":{}}}}],"meta":{"dois":[{"id":2014,"title":2014,"count":2640},{"id":2015,"title":2015,"count":96215},{"id":2016,"title":2016,"count":19451},{"id":2017,"title":2017,"count":3568},{"id":2018,"title":2018,"count":308}]}}'
     http_version: 
-  recorded_at: Tue, 19 Jun 2018 20:01:12 GMT
+  recorded_at: Tue, 19 Jun 2018 20:14:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Works/work_that_doesn_t_exist.yml
+++ b/spec/fixtures/vcr_cassettes/Works/work_that_doesn_t_exist.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://solr.test.datacite.org/api?defType=edismax&fq=doi:%2210.1098/rsif.2017.0030%22&q=10.1098/rsif.2017.0030&wt=json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Maremma 4.0.5 - https://github.com/datacite/maremma
+      Accept:
+      - text/html,application/json,application/xml;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Jun 2018 19:38:12 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.10.3 (Ubuntu)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
+      Access-Control-Expose-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
+    body:
+      encoding: ASCII-8BIT
+      string: '{"responseHeader":{"status":0,"QTime":4},"response":{"numFound":0,"start":0,"docs":[]}}
+
+'
+    http_version: 
+  recorded_at: Tue, 19 Jun 2018 19:38:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Works/work_that_doesn_t_exist.yml
+++ b/spec/fixtures/vcr_cassettes/Works/work_that_doesn_t_exist.yml
@@ -17,7 +17,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jun 2018 19:38:12 GMT
+      - Tue, 19 Jun 2018 20:14:11 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Connection:
@@ -34,9 +34,9 @@ http_interactions:
       - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization
     body:
       encoding: ASCII-8BIT
-      string: '{"responseHeader":{"status":0,"QTime":4},"response":{"numFound":0,"start":0,"docs":[]}}
+      string: '{"responseHeader":{"status":0,"QTime":3},"response":{"numFound":0,"start":0,"docs":[]}}
 
 '
     http_version: 
-  recorded_at: Tue, 19 Jun 2018 19:38:15 GMT
+  recorded_at: Tue, 19 Jun 2018 20:14:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Works/work_with_sign_in_doi.yml
+++ b/spec/fixtures/vcr_cassettes/Works/work_with_sign_in_doi.yml
@@ -17,7 +17,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jun 2018 19:38:36 GMT
+      - Tue, 19 Jun 2018 20:14:17 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Connection:
@@ -38,11 +38,11 @@ http_interactions:
         - DataCite","datacentre_facet":"DATACITE.DATACITE - DataCite","allocator":"DATACITE
         - DataCite","allocator_facet":"DATACITE - DataCite","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCAgICAgaHR0cDovL3NjaGVtYS5kYXRhY2l0ZS5vcmcvbWV0YS9rZXJuZWwtNC9tZXRhZGF0YS54c2QiPgogIDxpZGVudGlmaWVyIGlkZW50aWZpZXJUeXBlPSJET0kiPjEwLjE0NDU0L1RFUlJBQVFVQS9DRVJFUy9DTERUWVBISVNUX0wzLjAwNDwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPldvbmcsVGFrbWVuZzwvY3JlYXRvck5hbWU+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzPgogICAgPHRpdGxlPkNFUkVTIExldmVsIDMgQ2xvdWQgVHlwZSBIaXN0b3JncmFtIFRlcnJhK0FxdWEgSERGIGZpbGUgLSBFZGl0aW9uNDwvdGl0bGU+CiAgPC90aXRsZXM+CiAgPHB1Ymxpc2hlcj5OQVNBIExhbmdsZXkgQXRtb3NwaGVyaWMgU2NpZW5jZSBEYXRhIENlbnRlciBEQUFDPC9wdWJsaXNoZXI+CiAgPHB1YmxpY2F0aW9uWWVhcj4yMDE2PC9wdWJsaWNhdGlvblllYXI+CiAgPHJlc291cmNlVHlwZSByZXNvdXJjZVR5cGVHZW5lcmFsPSJEYXRhc2V0Ii8+CjwvcmVzb3VyY2U+","has_metadata":true,"allocator_symbol":"DATACITE","uploaded":"2018-05-21T07:53:28Z","namespace":"http://datacite.org/schema/kernel-4","checked":"2018-05-21T07:53:29Z","minted":"2018-05-21T08:00:47Z","state":"findable","updated":"2018-05-21T08:00:47Z","doi":"10.14454/TERRA+AQUA/CERES/CLDTYPHIST_L3.004","schema_version":"4","creator":["Wong,Takmeng"],"resourceTypeGeneral":"Dataset","publisher":"NASA
         Langley Atmospheric Science Data Center DAAC","publicationYear":"2016","title":["CERES
-        Level 3 Cloud Type Historgram Terra+Aqua HDF file - Edition4"],"resourceType":"","_version_":1603730922800152576,"indexed":"2018-06-19T19:36:31.501Z"}]}}
+        Level 3 Cloud Type Historgram Terra+Aqua HDF file - Edition4"],"resourceType":"","_version_":1603733124816044035,"indexed":"2018-06-19T20:11:31.508Z"}]}}
 
 '
     http_version: 
-  recorded_at: Tue, 19 Jun 2018 19:38:38 GMT
+  recorded_at: Tue, 19 Jun 2018 20:14:22 GMT
 - request:
     method: get
     uri: https://schema.test.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd
@@ -73,12 +73,14 @@ http_interactions:
       - '"6cc0617992b21daf1b6785c473f82b64"'
       Server:
       - AmazonS3
+      Age:
+      - '2141'
       X-Cache:
-      - Miss from cloudfront
+      - Hit from cloudfront
       Via:
-      - 1.1 940b367f846b05ee5d0f25268ff80731.cloudfront.net (CloudFront)
+      - 1.1 8ebc2b93de29d9744a950f4930f96579.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - zZV43RlOYj99lGM-7a9Un-EN_w9RcKqP0ggqVo4EEV3Mc4Sqqvjqgw==
+      - Y4jOPSo00kq4fdyEkN3aDTZVkYBRVxOsUj-b5V-O5uUR8TQ8KjCOaQ==
     body:
       encoding: ASCII-8BIT
       string: |
@@ -111,10 +113,10 @@ http_interactions:
           </xs:simpleType>
         </xs:schema>
     http_version: 
-  recorded_at: Tue, 19 Jun 2018 19:38:38 GMT
+  recorded_at: Tue, 19 Jun 2018 20:14:22 GMT
 - request:
     method: get
-    uri: https://app.datacite.org/clients/datacite.datacite
+    uri: https://app.test.datacite.org/clients/datacite.datacite
     body:
       encoding: US-ASCII
       string: ''
@@ -129,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 Jun 2018 19:38:36 GMT
+      - Tue, 19 Jun 2018 20:14:17 GMT
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Connection:
@@ -143,18 +145,20 @@ http_interactions:
       Vary:
       - Accept-Encoding, Origin
       X-Request-Id:
-      - 19c3086c-fdab-49b8-ac35-482fef1eb99e
+      - 51d77a24-a071-4b53-a913-4c769080dd45
       Etag:
-      - W/"1d98a8744740638ae455543b0599bd7f"
+      - W/"bd70377fd73442e1bd02e1baeae91297"
       X-Runtime:
-      - '0.012275'
+      - '0.008715'
       X-Powered-By:
       - Phusion Passenger 5.3.2
       Server:
       - nginx/1.14.0 + Phusion Passenger 5.3.2
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"datacite.datacite","type":"clients","attributes":{"name":"DataCite","symbol":"DATACITE.DATACITE","year":2011,"contact-name":"DataCite","contact-email":"support@datacite.org","domains":"*","url":null,"is-active":true,"has-password":true,"created":"2011-12-07T13:43:39Z","updated":"2018-06-19T02:30:09Z"},"relationships":{"prefixes":{"meta":{}},"provider":{"data":{"id":"datacite","type":"providers"}},"repository":{"data":null}}},"included":[{"id":"datacite","type":"providers","attributes":{"name":"DataCite","symbol":"DATACITE","website":null,"contact-name":"DataCite","contact-email":"support@datacite.org","phone":null,"description":null,"country":"DE","logo-url":null,"institution-type":null,"is-active":true,"has-password":true,"joined":null,"created":"2011-12-07T13:41:07.000Z","updated":"2018-06-19T02:25:58.000Z"},"relationships":{"clients":{"meta":{}},"prefixes":{"meta":{}}}}],"meta":{"dois":[{"id":2011,"title":2011,"count":6},{"id":2012,"title":2012,"count":1},{"id":2013,"title":2013,"count":3},{"id":2014,"title":2014,"count":3},{"id":2016,"title":2016,"count":69},{"id":2017,"title":2017,"count":26},{"id":2018,"title":2018,"count":29}]}}'
+      string: '{"data":{"id":"datacite.datacite","type":"clients","attributes":{"name":"DataCite","symbol":"DATACITE.DATACITE","year":2011,"contact-name":"Martin
+        Fenner","contact-email":"support@datacite.org","domains":"datacite.org","url":null,"is-active":true,"has-password":true,"created":"2011-12-07T13:43:39Z","updated":"2018-06-19T01:30:36Z"},"relationships":{"prefixes":{"meta":{}},"provider":{"data":{"id":"datacite","type":"providers"}},"repository":{"data":null}}},"included":[{"id":"datacite","type":"providers","attributes":{"name":"DataCite","symbol":"DATACITE","website":null,"contact-name":"DataCite
+        Support","contact-email":"support@datacite.org","phone":null,"description":null,"country":null,"logo-url":null,"institution-type":null,"is-active":true,"has-password":true,"joined":null,"created":"2011-12-07T13:41:07.000Z","updated":"2018-06-19T01:25:40.000Z"},"relationships":{"clients":{"meta":{}},"prefixes":{"meta":{}}}}],"meta":{"dois":[{"id":2016,"title":2016,"count":1},{"id":2018,"title":2018,"count":26}]}}'
     http_version: 
-  recorded_at: Tue, 19 Jun 2018 19:38:39 GMT
+  recorded_at: Tue, 19 Jun 2018 20:14:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Works/work_with_sign_in_doi.yml
+++ b/spec/fixtures/vcr_cassettes/Works/work_with_sign_in_doi.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://solr.test.datacite.org/api?defType=edismax&q=10.14454/terra%2Baqua/ceres/cldtyphist_l3.004&wt=json
+    uri: https://solr.test.datacite.org/api?defType=edismax&fq=doi:%2210.14454/terra%2Baqua/ceres/cldtyphist_l3.004%22&q=10.14454/terra%2Baqua/ceres/cldtyphist_l3.004&wt=json
     body:
       encoding: US-ASCII
       string: ''
@@ -17,7 +17,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 May 2018 08:19:49 GMT
+      - Tue, 19 Jun 2018 19:38:36 GMT
       Content-Type:
       - application/json;charset=UTF-8
       Connection:
@@ -38,11 +38,11 @@ http_interactions:
         - DataCite","datacentre_facet":"DATACITE.DATACITE - DataCite","allocator":"DATACITE
         - DataCite","allocator_facet":"DATACITE - DataCite","xml":"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHJlc291cmNlIHhtbG5zPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCIgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vZGF0YWNpdGUub3JnL3NjaGVtYS9rZXJuZWwtNCAgICAgaHR0cDovL3NjaGVtYS5kYXRhY2l0ZS5vcmcvbWV0YS9rZXJuZWwtNC9tZXRhZGF0YS54c2QiPgogIDxpZGVudGlmaWVyIGlkZW50aWZpZXJUeXBlPSJET0kiPjEwLjE0NDU0L1RFUlJBQVFVQS9DRVJFUy9DTERUWVBISVNUX0wzLjAwNDwvaWRlbnRpZmllcj4KICA8Y3JlYXRvcnM+CiAgICA8Y3JlYXRvcj4KICAgICAgPGNyZWF0b3JOYW1lPldvbmcsVGFrbWVuZzwvY3JlYXRvck5hbWU+CiAgICA8L2NyZWF0b3I+CiAgPC9jcmVhdG9ycz4KICA8dGl0bGVzPgogICAgPHRpdGxlPkNFUkVTIExldmVsIDMgQ2xvdWQgVHlwZSBIaXN0b3JncmFtIFRlcnJhK0FxdWEgSERGIGZpbGUgLSBFZGl0aW9uNDwvdGl0bGU+CiAgPC90aXRsZXM+CiAgPHB1Ymxpc2hlcj5OQVNBIExhbmdsZXkgQXRtb3NwaGVyaWMgU2NpZW5jZSBEYXRhIENlbnRlciBEQUFDPC9wdWJsaXNoZXI+CiAgPHB1YmxpY2F0aW9uWWVhcj4yMDE2PC9wdWJsaWNhdGlvblllYXI+CiAgPHJlc291cmNlVHlwZSByZXNvdXJjZVR5cGVHZW5lcmFsPSJEYXRhc2V0Ii8+CjwvcmVzb3VyY2U+","has_metadata":true,"allocator_symbol":"DATACITE","uploaded":"2018-05-21T07:53:28Z","namespace":"http://datacite.org/schema/kernel-4","checked":"2018-05-21T07:53:29Z","minted":"2018-05-21T08:00:47Z","state":"findable","updated":"2018-05-21T08:00:47Z","doi":"10.14454/TERRA+AQUA/CERES/CLDTYPHIST_L3.004","schema_version":"4","creator":["Wong,Takmeng"],"resourceTypeGeneral":"Dataset","publisher":"NASA
         Langley Atmospheric Science Data Center DAAC","publicationYear":"2016","title":["CERES
-        Level 3 Cloud Type Historgram Terra+Aqua HDF file - Edition4"],"resourceType":"","_version_":1601060829714710530,"indexed":"2018-05-21T08:16:32.303Z"}]}}
+        Level 3 Cloud Type Historgram Terra+Aqua HDF file - Edition4"],"resourceType":"","_version_":1603730922800152576,"indexed":"2018-06-19T19:36:31.501Z"}]}}
 
 '
     http_version: 
-  recorded_at: Mon, 21 May 2018 08:19:50 GMT
+  recorded_at: Tue, 19 Jun 2018 19:38:38 GMT
 - request:
     method: get
     uri: https://schema.test.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd
@@ -64,7 +64,7 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 21 May 2018 08:19:50 GMT
+      - Tue, 19 Jun 2018 19:38:37 GMT
       Content-Encoding:
       - text
       Last-Modified:
@@ -76,9 +76,9 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 f7c2c81dcd8f9c4723ba9992c4abd851.cloudfront.net (CloudFront)
+      - 1.1 940b367f846b05ee5d0f25268ff80731.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - br-bPDHGeNzm9-xfU_8tyQPJ7d3z3HB3mS3sBoKmqU-QnmrfsPwceQ==
+      - zZV43RlOYj99lGM-7a9Un-EN_w9RcKqP0ggqVo4EEV3Mc4Sqqvjqgw==
     body:
       encoding: ASCII-8BIT
       string: |
@@ -111,10 +111,10 @@ http_interactions:
           </xs:simpleType>
         </xs:schema>
     http_version: 
-  recorded_at: Mon, 21 May 2018 08:19:50 GMT
+  recorded_at: Tue, 19 Jun 2018 19:38:38 GMT
 - request:
     method: get
-    uri: https://app.test.datacite.org/clients/datacite.datacite
+    uri: https://app.datacite.org/clients/datacite.datacite
     body:
       encoding: US-ASCII
       string: ''
@@ -129,7 +129,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 21 May 2018 08:19:49 GMT
+      - Tue, 19 Jun 2018 19:38:36 GMT
       Content-Type:
       - application/vnd.api+json; charset=utf-8
       Connection:
@@ -143,20 +143,18 @@ http_interactions:
       Vary:
       - Accept-Encoding, Origin
       X-Request-Id:
-      - b7c1b40f-0b3d-4f89-983a-a28be13a6eb2
+      - 19c3086c-fdab-49b8-ac35-482fef1eb99e
       Etag:
-      - W/"6fff8219d8f1a7492c3ca1600a3213d0"
+      - W/"1d98a8744740638ae455543b0599bd7f"
       X-Runtime:
-      - '0.008473'
+      - '0.012275'
       X-Powered-By:
-      - Phusion Passenger 5.3.1
+      - Phusion Passenger 5.3.2
       Server:
-      - nginx/1.14.0 + Phusion Passenger 5.3.1
+      - nginx/1.14.0 + Phusion Passenger 5.3.2
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"datacite.datacite","type":"clients","attributes":{"name":"DataCite","symbol":"DATACITE.DATACITE","year":2011,"contact-name":"Martin
-        Fenner","contact-email":"support@datacite.org","domains":"datacite.org","url":null,"is-active":true,"has-password":true,"created":"2011-12-07T13:43:39Z","updated":"2018-05-21T01:30:25Z"},"relationships":{"prefixes":{"meta":{}},"provider":{"data":{"id":"datacite","type":"providers"}},"repository":{"data":null}}},"included":[{"id":"datacite","type":"providers","attributes":{"name":"DataCite","symbol":"DATACITE","website":null,"contact-name":"DataCite
-        Support","contact-email":"support@datacite.org","phone":null,"description":null,"country":null,"logo-url":null,"institution-type":null,"is-active":true,"has-password":true,"joined":null,"created":"2011-12-07T13:41:07.000Z","updated":"2018-05-21T01:25:40.000Z"},"relationships":{"clients":{"meta":{}},"prefixes":{"meta":{}}}}],"meta":{"dois":[{"id":2016,"title":2016,"count":1},{"id":2018,"title":2018,"count":13}]}}'
+      string: '{"data":{"id":"datacite.datacite","type":"clients","attributes":{"name":"DataCite","symbol":"DATACITE.DATACITE","year":2011,"contact-name":"DataCite","contact-email":"support@datacite.org","domains":"*","url":null,"is-active":true,"has-password":true,"created":"2011-12-07T13:43:39Z","updated":"2018-06-19T02:30:09Z"},"relationships":{"prefixes":{"meta":{}},"provider":{"data":{"id":"datacite","type":"providers"}},"repository":{"data":null}}},"included":[{"id":"datacite","type":"providers","attributes":{"name":"DataCite","symbol":"DATACITE","website":null,"contact-name":"DataCite","contact-email":"support@datacite.org","phone":null,"description":null,"country":"DE","logo-url":null,"institution-type":null,"is-active":true,"has-password":true,"joined":null,"created":"2011-12-07T13:41:07.000Z","updated":"2018-06-19T02:25:58.000Z"},"relationships":{"clients":{"meta":{}},"prefixes":{"meta":{}}}}],"meta":{"dois":[{"id":2011,"title":2011,"count":6},{"id":2012,"title":2012,"count":1},{"id":2013,"title":2013,"count":3},{"id":2014,"title":2014,"count":3},{"id":2016,"title":2016,"count":69},{"id":2017,"title":2017,"count":26},{"id":2018,"title":2018,"count":29}]}}'
     http_version: 
-  recorded_at: Mon, 21 May 2018 08:19:51 GMT
+  recorded_at: Tue, 19 Jun 2018 19:38:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -19,7 +19,7 @@ describe Work, type: :model, vcr: true do
     end
 
     it "with id" do
-      expect(Work.get_query_url(id: "10.5061/DRYAD.Q447C")).to eq("https://solr.test.datacite.org/api?q=10.5061%2FDRYAD.Q447C&defType=edismax&wt=json")
+      expect(Work.get_query_url(id: "10.5061/DRYAD.Q447C")).to eq("https://solr.test.datacite.org/api?q=10.5061%2FDRYAD.Q447C&fq=doi%3A%2210.5061%2FDRYAD.Q447C%22&defType=edismax&wt=json")
     end
 
     it "with work_id" do

--- a/spec/requests/works_spec.rb
+++ b/spec/requests/works_spec.rb
@@ -211,6 +211,15 @@ describe "Works", type: :request, vcr: true do
     expect(work.dig("attributes", "title")).to eq("DAT-3025 Maintain file ordering for published datasets - 4")
   end
 
+  it "work that doesn't exist" do
+    get '/works/10.1098/rsif.2017.0030'
+
+    expect(last_response.status).to eq(404)
+
+    errors = json["errors"]
+    expect(errors.first.dig("title")).to eq("The resource you are looking for doesn't exist.")
+  end
+
   it "work with + sign in doi" do
     get '/works/10.14454/terra+aqua/ceres/cldtyphist_l3.004'
 


### PR DESCRIPTION
It filters query results for by DOI, so when there is a request for a DOI you actually get the metadata of that DOI and not the metadata of other DOIS that might be in the metadata. it fixes datacite/spinone#43